### PR TITLE
fix: 拖拽列宽时会选中文本

### DIFF
--- a/packages/table/src/components/HeaderCell.vue
+++ b/packages/table/src/components/HeaderCell.vue
@@ -123,9 +123,11 @@ const canFilter = computed(() => columnDef.value.enableColumnFilter)
 const canResize = computed(() => column.value.getCanResize())
 const handleMouseDown = (event: MouseEvent) => {
   props.header.getResizeHandler()?.(event)
+  document.body.style.userSelect = 'auto'
 }
 const handleTouchStart = (event: TouchEvent) => {
   props.header.getResizeHandler()?.(event)
+  document.body.style.userSelect = 'none'
 }
 const handleDoubleClick = () => {
   column.value.resetSize()


### PR DESCRIPTION
列宽拖拽时，需要先禁用选择文本，拖拽结束再解开限制